### PR TITLE
 Remove custom: from hostnames (label)

### DIFF
--- a/component-tests/test_management.py
+++ b/component-tests/test_management.py
@@ -40,7 +40,7 @@ class TestManagement:
             
             # Assert response json.
             assert resp.status_code == 200, "Expected cloudflared to return 200 for host details"
-            assert resp.json()["hostname"] == "custom:test", "Expected cloudflared to return hostname"
+            assert resp.json()["hostname"] == "test", "Expected cloudflared to return hostname"
             assert resp.json()["ip"] != "", "Expected cloudflared to return ip"
             assert resp.json()["connector_id"] == connector_id, "Expected cloudflared to return connector_id"
     

--- a/management/service.go
+++ b/management/service.go
@@ -134,7 +134,7 @@ func (m *ManagementService) getHostDetails(w http.ResponseWriter, r *http.Reques
 
 func (m *ManagementService) getLabel() string {
 	if m.label != "" {
-		return fmt.Sprintf("custom:%s", m.label)
+		return fmt.Sprintf("%s", m.label)
 	}
 
 	// If no label is provided we return the system hostname. This is not


### PR DESCRIPTION
Remove additional length from custom connector labels and hostnames should only contain 'a-z', 'A-Z', '0-9', '-' and '.'
